### PR TITLE
Update rarbg: add logged-in matcher (captcha lock)

### DIFF
--- a/imdb-link-em-all.user.js
+++ b/imdb-link-em-all.user.js
@@ -432,7 +432,8 @@ const sites = [
       'https://rarbg.to/torrents.php?search={{IMDB_TITLE}}+{{IMDB_YEAR}}',
       function($dom) {
         return $dom.find('.lista2t tr').length > 1;
-      }
+      },
+      'Please wait while we try to verify your browser...'
     ],
     '1337x': [
       '1337x',


### PR DESCRIPTION
Occasionally, rarbg pops a captcha lock on the website, preventing all access. Without the logged-in matcher, the script shows the no results icon, which is misleading.