### PR TITLE
Improving Blu-ray.com to list movies instead of releases

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -256,7 +256,7 @@
     "id": "bluraycom",
     "title": "Blu-ray.com",
     "icon": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAYFBMVEVGmt1IneBKoOJMouNNpORPpeVQqOdRqulSrOpfqeNUrOpVruxXse9ZtfFdufR2uux+wfCFwe2Cx/Sby++czfCkz/Cg0/Wo1POr2Pes2vi73fXK5fnV6vno9P30+v3///8V2ZdfAAAAf0lEQVQYGQXBS07DQABAMWeYQiskPve/IYuWBUhAOnnY2wuIpKMJz+j4vS81MR/BZb+WQTjWwemchmC/Xe88VQNgbfypGTi9b8P+VU3CQKsy5GD93G3n1zQS9tvHNxcZAiykmXXi4TKfOTAFpzd0i7kUWL+fO7ZzpRJhVCoR/AMNol6wavG87wAAAABJRU5ErkJggg==",
-    "url": "http://www.blu-ray.com/movies/search.php?keyword={{IMDB_TITLE}}&yearfrom={{IMDB_YEAR}}&yearto={{IMDB_YEAR}}&submit=Search&action=search",
+    "url": "https://www.blu-ray.com/products/search.php?title={{IMDB_TITLE}}&year_min={{IMDB_YEAR}}&year_maxrange=20145&year_max=20145&year_exact=0&action=search&c=20&searchsubmit=Search&sortby=productionyeardesc",
     "noResultsMatcher": "Sorry, your search didn't return any results.",
     "category": "movie_site"
   },


### PR DESCRIPTION
This way the website lists the movies it finds instead of the releases. Here the min year could be improved by having a variable with the year IMDB has an subtracting 1 or 2,  as there have been cases where Blu-ray.com listed a movie at certain year (ie. 2002) and IMDB has it with another year (ie. 2003) but in my experience those are rare cases.