### PR TITLE
YTS/YIFY Search Improvements

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -533,7 +533,7 @@
     "id": "yts",
     "title": "YTS",
     "icon": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQBAMAAADt3eJSAAAAMFBMVEUgHiEbICIeIB0dKh8bMxwaQRwWUxgTYBYRbRINdA8Chw4BmgkJpgAAtgAAvwAAygD2IFtIAAAAm0lEQVQI1wGQAG//ACAEMQIiASIiACBlIRAhABACABaAEREAIhEQADoxIqtxi6IiAHkiELy03WEBALcCEG7d2SAQANYQIi3uwgEiANYgEivuQAIQANchACr7IgACAMoiICz3ECEBAJ1AIh/UIgIDAD2wIl+yABA2ABfaEDVBACSkAAGetQEiIntgAAIX38qZrMYgACACKM7ttxASm8omLNhBbCUAAAAASUVORK5CYII=",
-    "url": "https://yts.ag/browse-movies/{{IMDB_TITLE}}",
+    "url": "https://yts.mx/browse-movies/tt{{IMDB_ID}}",
     "noResultsMatcher": "<b>0</b>",
     "category": "pub_tracker"
   },


### PR DESCRIPTION
Changed yts.ag to the primary url of yts.mx as indicated by the official ytsstatus and ytsproxies pages.

Changed from title based search to ID based search to get the correct result every time when searching common titles.

Before
![Screenshot_20240921_155844_Firefox](https://github.com/user-attachments/assets/8c3404c9-be97-4d32-8b06-da4fe41c48fd)

After
![Screenshot_20240921_155857_Firefox](https://github.com/user-attachments/assets/ab960381-ba89-40ae-bd36-1f77ee133d94)
